### PR TITLE
change in line 105 of uCal.class.php

### DIFF
--- a/uCal.class.php
+++ b/uCal.class.php
@@ -102,7 +102,7 @@ class uCal {
 		$m=$i-12*$ii; // month
 		$d=$mjd-$this->jdl[$i-1]; //day
 		$ml=$this->jdl[$i]-$this->jdl[$i-1];// Month Length
-		list ($id[month], $id[day], $id[year], $id[ln], $id[ml]) = explode("/","$m/$d/$y/$iln/$ml");
+		list ($id['month'], $id['day'], $id['year'], $id['ln'], $id['ml']) = explode("/","$m/$d/$y/$iln/$ml");
 		return ($id);
 	}
       /**


### PR DESCRIPTION
WordPress Debug giving a notice for line 105 in uCal.class.php. Fixed it!
used $id['month'], $id['day'], $id['year'], $id['ln'], $id['ml'] instead of $id[month], $id[day], $id[year], $id[ln], $id[ml]
